### PR TITLE
Fix setting is connected flag inside BleDevice

### DIFF
--- a/android/src/main/java/com/polidea/flutterblelib/Converter.java
+++ b/android/src/main/java/com/polidea/flutterblelib/Converter.java
@@ -142,11 +142,15 @@ class Converter {
     }
 
     BleData.BleDeviceMessage convertToBleDeviceMessage(RxBleDevice device, int mtu, int rssi) {
+        final boolean isConnected = device.getConnectionState()
+                .equals(RxBleConnection.RxBleConnectionState.CONNECTED);
+
         return BleData.BleDeviceMessage.newBuilder()
                 .setId(stringUtils.safeNullInstance(device.getMacAddress()))
                 .setName(stringUtils.safeNullInstance(device.getName()))
                 .setMtu(mtu)
                 .setRssi(rssi)
+                .setIsConnected(isConnected)
                 .build();
     }
 

--- a/ios/Classes/BleData/Bledata.pbobjc.h
+++ b/ios/Classes/BleData/Bledata.pbobjc.h
@@ -125,6 +125,7 @@ typedef GPB_ENUM(BleDataBleDeviceMessage_FieldNumber) {
   BleDataBleDeviceMessage_FieldNumber_Name = 2,
   BleDataBleDeviceMessage_FieldNumber_Rssi = 3,
   BleDataBleDeviceMessage_FieldNumber_Mtu = 4,
+  BleDataBleDeviceMessage_FieldNumber_IsConnected = 5,
 };
 
 @interface BleDataBleDeviceMessage : GPBMessage
@@ -136,6 +137,8 @@ typedef GPB_ENUM(BleDataBleDeviceMessage_FieldNumber) {
 @property(nonatomic, readwrite) int32_t rssi;
 
 @property(nonatomic, readwrite) int32_t mtu;
+
+@property(nonatomic, readwrite) BOOL isConnected;
 
 @end
 

--- a/ios/Classes/BleData/Bledata.pbobjc.m
+++ b/ios/Classes/BleData/Bledata.pbobjc.m
@@ -206,6 +206,7 @@ typedef struct BleDataScanDataMessage__storage_ {
 @dynamic name;
 @dynamic rssi;
 @dynamic mtu;
+@dynamic isConnected;
 
 typedef struct BleDataBleDeviceMessage__storage_ {
   uint32_t _has_storage_[1];
@@ -257,6 +258,15 @@ typedef struct BleDataBleDeviceMessage__storage_ {
         .flags = GPBFieldOptional,
         .dataType = GPBDataTypeInt32,
       },
+      {
+        .name = "isConnected",
+        .dataTypeSpecific.className = NULL,
+        .number = BleDataBleDeviceMessage_FieldNumber_IsConnected,
+        .hasIndex = 4,
+        .offset = 5,  // Stored in _has_storage_ to save space.
+        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldTextFormatNameCustom),
+        .dataType = GPBDataTypeBool,
+      },
     };
     GPBDescriptor *localDescriptor =
         [GPBDescriptor allocDescriptorForClass:[BleDataBleDeviceMessage class]
@@ -266,6 +276,11 @@ typedef struct BleDataBleDeviceMessage__storage_ {
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
                                    storageSize:sizeof(BleDataBleDeviceMessage__storage_)
                                          flags:GPBDescriptorInitializationFlag_None];
+#if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
+    static const char *extraTextFormatInfo =
+        "\001\005\013\000";
+    [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
+#endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;
   }

--- a/lib/generated/bledata.pb.dart
+++ b/lib/generated/bledata.pb.dart
@@ -57,6 +57,7 @@ class BleDeviceMessage extends GeneratedMessage {
     ..a<String>(2, 'name', PbFieldType.OS)
     ..a<int>(3, 'rssi', PbFieldType.O3)
     ..a<int>(4, 'mtu', PbFieldType.O3)
+    ..a<bool>(5, 'isConnected', PbFieldType.OB)
     ..hasRequiredFields = false
   ;
 
@@ -95,6 +96,11 @@ class BleDeviceMessage extends GeneratedMessage {
   set mtu(int v) { $_setUnsignedInt32(3, 4, v); }
   bool hasMtu() => $_has(3, 4);
   void clearMtu() => clearField(4);
+
+  bool get isConnected => $_get(4, 5, false);
+  set isConnected(bool v) { $_setBool(4, 5, v); }
+  bool hasIsConnected() => $_has(4, 5);
+  void clearIsConnected() => clearField(5);
 }
 
 class _ReadonlyBleDeviceMessage extends BleDeviceMessage with ReadonlyMessageMixin {}

--- a/lib/generated/bledata.pbjson.dart
+++ b/lib/generated/bledata.pbjson.dart
@@ -44,6 +44,7 @@ const BleDeviceMessage$json = const {
     const {'1': 'name', '3': 2, '4': 1, '5': 9, '10': 'name'},
     const {'1': 'rssi', '3': 3, '4': 1, '5': 5, '10': 'rssi'},
     const {'1': 'mtu', '3': 4, '4': 1, '5': 5, '10': 'mtu'},
+    const {'1': 'isConnected', '3': 5, '4': 1, '5': 8, '10': 'isConnected'},
   ],
 };
 

--- a/lib/source/lib_models.dart
+++ b/lib/source/lib_models.dart
@@ -8,11 +8,12 @@ class BleDevice {
   int rssi;
   bool isConnected = false;
 
-  BleDevice(this.id, this.name, this.mtu, this.rssi);
+  BleDevice(this.id, this.name, this.mtu, this.rssi, this.isConnected);
 
   static BleDevice fromMessage(bleData.BleDeviceMessage bleDeviceMessage) =>
       new BleDevice(bleDeviceMessage.id, bleDeviceMessage.name,
-          bleDeviceMessage.mtu, bleDeviceMessage.rssi);
+          bleDeviceMessage.mtu, bleDeviceMessage.rssi,
+          bleDeviceMessage.isConnected);
 
   @override
   String toString() {

--- a/protos/bledata.proto
+++ b/protos/bledata.proto
@@ -19,6 +19,7 @@ message BleDeviceMessage {
     string name = 2;
     int32 rssi = 3;
     int32 mtu = 4;
+    bool isConnected = 5;
 }
 
 message ScanResultMessage {


### PR DESCRIPTION
With this commit, BleDevice isConnected field is correctly set.
Previously it was always set to false.

This PR is fixing it only for Android, iOS needs similar fix.