### PR TITLE
Handling multiple stream observers

### DIFF
--- a/lib/characteristic.dart
+++ b/lib/characteristic.dart
@@ -25,7 +25,7 @@ class Characteristic extends InternalCharacteristic {
       ManagerForCharacteristic manager)
       : super(jsonObject[_CharacteristicMetadata.id]) {
     _manager = manager;
-    service = service;
+    this.service = service;
     uuid = jsonObject[_CharacteristicMetadata.uuid];
     isReadable = jsonObject[_CharacteristicMetadata.isReadable];
     isWritableWithResponse =

--- a/lib/characteristic.dart
+++ b/lib/characteristic.dart
@@ -11,11 +11,10 @@ abstract class _CharacteristicMetadata {
   static const String value = "value";
 }
 
-class Characteristic {
+class Characteristic extends InternalCharacteristic {
   Service service;
   ManagerForCharacteristic _manager;
   String uuid;
-  int _id;
   bool isReadable;
   bool isWritableWithResponse;
   bool isWritableWithoutResponse;
@@ -24,22 +23,23 @@ class Characteristic {
 
   Characteristic.fromJson(Map<String, dynamic> jsonObject, Service service,
       ManagerForCharacteristic manager)
-      : _manager = manager,
-        service = service,
-        _id = jsonObject[_CharacteristicMetadata.id],
-        uuid = jsonObject[_CharacteristicMetadata.uuid],
-        isReadable = jsonObject[_CharacteristicMetadata.isReadable],
-        isWritableWithResponse =
-            jsonObject[_CharacteristicMetadata.isWritableWithResponse],
-        isWritableWithoutResponse =
-            jsonObject[_CharacteristicMetadata.isWritableWithoutResponse],
-        isNotifiable = jsonObject[_CharacteristicMetadata.isNotifiable],
-        isIndicatable = jsonObject[_CharacteristicMetadata.isIndicatable];
+      : super(jsonObject[_CharacteristicMetadata.id]) {
+    _manager = manager;
+    service = service;
+    uuid = jsonObject[_CharacteristicMetadata.uuid];
+    isReadable = jsonObject[_CharacteristicMetadata.isReadable];
+    isWritableWithResponse =
+        jsonObject[_CharacteristicMetadata.isWritableWithResponse];
+    isWritableWithoutResponse =
+        jsonObject[_CharacteristicMetadata.isWritableWithoutResponse];
+    isNotifiable = jsonObject[_CharacteristicMetadata.isNotifiable];
+    isIndicatable = jsonObject[_CharacteristicMetadata.isIndicatable];
+  }
 
   Future<Uint8List> read({String transactionId}) =>
       _manager.readCharacteristicForIdentifier(
         service.peripheral,
-        _id,
+        this,
         transactionId,
       );
 
@@ -50,7 +50,7 @@ class Characteristic {
   }) =>
       _manager.writeCharacteristicForIdentifier(
         service.peripheral,
-        _id,
+        this,
         bytes,
         withResponse,
         transactionId,
@@ -59,7 +59,7 @@ class Characteristic {
   Stream<Uint8List> monitor({String transactionId}) =>
       _manager.monitorCharacteristicForIdentifier(
         service.peripheral,
-        _id,
+        this,
         transactionId,
       );
 }

--- a/lib/error/ble_error.dart
+++ b/lib/error/ble_error.dart
@@ -35,4 +35,17 @@ class BleError {
         characteristicUUID = json[_BleErrorMetadata.CHARACTERISTIC_UUID],
         descriptorUUID = json[_BleErrorMetadata.DESCRIPTOR_UUID],
         internalMessage = json[_BleErrorMetadata.INTERNAL_MESSAGE];
+
+  @override
+  String toString() => "BleError ("
+      "Error code: $errorCode, "
+      "ATT error code: $attErrorCode, "
+      "iOS error code: $iosErrorCode, "
+      "Android error code: $androidErrorCode, "
+      "reason: $reason, "
+      "internal message: $internalMessage, "
+      "device ID: $deviceID, "
+      "service UUID: $serviceUUID, "
+      "characteristic UUID: $characteristicUUID, "
+      "descriptor UUID: $descriptorUUID)";
 }

--- a/lib/internal/base_entities.dart
+++ b/lib/internal/base_entities.dart
@@ -5,3 +5,9 @@ class InternalService {
 
   InternalService(this._id);
 }
+
+class InternalCharacteristic {
+  int _id;
+
+  InternalCharacteristic(this._id);
+}

--- a/lib/internal/bridge/bluetooth_state_mixin.dart
+++ b/lib/internal/bridge/bluetooth_state_mixin.dart
@@ -1,8 +1,8 @@
 part of internal_bridge_lib;
 
 mixin BluetoothStateMixin on FlutterBLE {
-  final EventChannel _adapterStateChanges =
-      const EventChannel(ChannelName.adapterStateChanges);
+  final Stream<dynamic> _adapterStateChanges =
+      const EventChannel(ChannelName.adapterStateChanges).receiveBroadcastStream();
 
   Future<void> enableRadio(String transactionId) async {
     await _methodChannel.invokeMethod(
@@ -33,9 +33,7 @@ mixin BluetoothStateMixin on FlutterBLE {
       BluetoothState currentState = await state();
       yield currentState;
     }
-    yield* _adapterStateChanges
-        .receiveBroadcastStream()
-        .map(_mapToBluetoothState);
+    yield* _adapterStateChanges.map(_mapToBluetoothState);
   }
 
   BluetoothState _mapToBluetoothState(dynamic rawValue) {

--- a/lib/internal/bridge/characteristics_mixin.dart
+++ b/lib/internal/bridge/characteristics_mixin.dart
@@ -179,17 +179,11 @@ mixin CharacteristicsMixin on FlutterBLE {
       },
     );
     yield* _characteristicsMonitoringEvents
-        .map(
-          (rawJsonValue) =>
-              _parseCharacteristicResponse(peripheral, rawJsonValue),
-        )
-        .where(
-          (characteristic) =>
-              compareAsciiLowerCase(characteristicUUID, characteristic.uuid) ==
-                  0 &&
-              compareAsciiLowerCase(serviceUuid, characteristic.service.uuid) ==
-                  0,
-        )
+        .map((rawJsonValue) =>
+            _parseCharacteristicResponse(peripheral, rawJsonValue))
+        .where((characteristic) =>
+            equalsIgnoreAsciiCase(characteristicUUID, characteristic.uuid) &&
+            equalsIgnoreAsciiCase(serviceUuid, characteristic.service.uuid))
         .handleError((errorJson) =>
             throw BleError.fromJson(jsonDecode(errorJson.details)));
   }
@@ -215,8 +209,7 @@ mixin CharacteristicsMixin on FlutterBLE {
         )
         .where(
           (characteristic) =>
-              compareAsciiLowerCase(characteristicUUID, characteristic.uuid) ==
-                  0 &&
+              equalsIgnoreAsciiCase(characteristicUUID, characteristic.uuid) &&
               serviceIdentifier == characteristic.service._id,
         )
         .handleError((errorJson) =>

--- a/lib/internal/bridge/characteristics_mixin.dart
+++ b/lib/internal/bridge/characteristics_mixin.dart
@@ -1,8 +1,9 @@
 part of internal_bridge_lib;
 
 mixin CharacteristicsMixin on FlutterBLE {
-  final EventChannel _monitoringChannel =
-      const EventChannel(ChannelName.monitorCharacteristic);
+  final Stream<dynamic> _characteristicsMonitoringEvents =
+      const EventChannel(ChannelName.monitorCharacteristic)
+          .receiveBroadcastStream();
 
   Future<Uint8List> readCharacteristicForIdentifier(
     Peripheral peripheral,
@@ -149,11 +150,13 @@ mixin CharacteristicsMixin on FlutterBLE {
         ArgumentName.transactionId: transactionId,
       },
     );
-    yield* _monitoringChannel
-        .receiveBroadcastStream()
+    yield* _characteristicsMonitoringEvents
         .map(
           (rawJsonValue) =>
               _parseCharacteristicResponse(peripheral, rawJsonValue),
+        )
+        .where(
+          (characteristic) => characteristic._id == characteristicIdentifier,
         )
         .map((characteristicWithValue) => characteristicWithValue.value)
         .handleError((errorJson) =>
@@ -175,11 +178,17 @@ mixin CharacteristicsMixin on FlutterBLE {
         ArgumentName.transactionId: transactionId,
       },
     );
-    yield* _monitoringChannel
-        .receiveBroadcastStream()
+    yield* _characteristicsMonitoringEvents
         .map(
           (rawJsonValue) =>
               _parseCharacteristicResponse(peripheral, rawJsonValue),
+        )
+        .where(
+          (characteristic) =>
+              compareAsciiLowerCase(characteristicUUID, characteristic.uuid) ==
+                  0 &&
+              compareAsciiLowerCase(serviceUuid, characteristic.service.uuid) ==
+                  0,
         )
         .handleError((errorJson) =>
             throw BleError.fromJson(jsonDecode(errorJson.details)));
@@ -199,11 +208,16 @@ mixin CharacteristicsMixin on FlutterBLE {
         ArgumentName.transactionId: transactionId,
       },
     );
-    yield* _monitoringChannel
-        .receiveBroadcastStream()
+    yield* _characteristicsMonitoringEvents
         .map(
           (rawJsonValue) =>
               _parseCharacteristicResponse(peripheral, rawJsonValue),
+        )
+        .where(
+          (characteristic) =>
+              compareAsciiLowerCase(characteristicUUID, characteristic.uuid) ==
+                  0 &&
+              serviceIdentifier == characteristic.service._id,
         )
         .handleError((errorJson) =>
             throw BleError.fromJson(jsonDecode(errorJson.details)));

--- a/lib/internal/bridge/internal_bridge_lib.dart
+++ b/lib/internal/bridge/internal_bridge_lib.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_ble_lib/flutter_ble_lib.dart';
 import 'package:flutter_ble_lib/internal/constants.dart';
 import 'package:flutter_ble_lib/internal/containers.dart';
+import 'package:collection/collection.dart';
 
 import '../managers_for_classes.dart';
 

--- a/lib/internal/bridge/lib_core.dart
+++ b/lib/internal/bridge/lib_core.dart
@@ -18,15 +18,14 @@ class FlutterBleLib extends FlutterBLE
         BluetoothStateMixin,
         DevicesMixin,
         CharacteristicsMixin {
-  final EventChannel _restoreStateEventChannel =
-      const EventChannel(ChannelName.stateRestoreEvents);
+  final Stream<dynamic> _restoreStateEvents =
+      const EventChannel(ChannelName.stateRestoreEvents).receiveBroadcastStream();
 
   void registerManager(InternalBleManager manager) {
     _manager = manager;
   }
 
-  Future<List<Peripheral>> restoredState() => _restoreStateEventChannel
-      .receiveBroadcastStream()
+  Future<List<Peripheral>> restoredState() => _restoreStateEvents
       .map(
         (jsonString) {
           if (jsonString == null)

--- a/lib/internal/bridge/scanning_mixin.dart
+++ b/lib/internal/bridge/scanning_mixin.dart
@@ -1,8 +1,8 @@
 part of internal_bridge_lib;
 
 mixin ScanningMixin on FlutterBLE {
-  final EventChannel _scanEventChannel =
-      const EventChannel(ChannelName.scanningEvents);
+  final Stream<dynamic> _scanEvents =
+      const EventChannel(ChannelName.scanningEvents).receiveBroadcastStream();
 
   Stream<ScanResult> startDeviceScan(
     int scanMode,
@@ -17,7 +17,7 @@ mixin ScanningMixin on FlutterBLE {
         ArgumentName.uuids: uuids
       },
     );
-    yield* _scanEventChannel.receiveBroadcastStream().handleError(
+    yield* _scanEvents.handleError(
       (errorJson) {
         throw BleError.fromJson(jsonDecode(errorJson.details));
       },

--- a/lib/internal/internal_ble_manager.dart
+++ b/lib/internal/internal_ble_manager.dart
@@ -145,10 +145,13 @@ class InternalBleManager
   }
 
   @override
-  Future<Uint8List> readCharacteristicForIdentifier(Peripheral peripheral,
-          int characteristicIdentifier, String transactionId) =>
+  Future<Uint8List> readCharacteristicForIdentifier(
+    Peripheral peripheral,
+    InternalCharacteristic characteristic,
+    String transactionId,
+  ) =>
       _bleLib.readCharacteristicForIdentifier(
-          peripheral, characteristicIdentifier, transactionId);
+          peripheral, characteristic._id, transactionId);
 
   @override
   Future<CharacteristicWithValue> readCharacteristicForDevice(
@@ -179,13 +182,13 @@ class InternalBleManager
   @override
   Future<void> writeCharacteristicForIdentifier(
           Peripheral peripheral,
-          int characteristicIdentifier,
+          InternalCharacteristic characteristic,
           Uint8List bytes,
           bool withResponse,
           String transactionId) =>
       _bleLib.writeCharacteristicForIdentifier(
         peripheral,
-        characteristicIdentifier,
+        characteristic._id,
         bytes,
         withResponse,
         transactionId,
@@ -256,12 +259,12 @@ class InternalBleManager
   @override
   Stream<Uint8List> monitorCharacteristicForIdentifier(
     Peripheral peripheral,
-    int characteristicIdentifier,
+    InternalCharacteristic characteristic,
     String transactionId,
   ) =>
       _bleLib.monitorCharacteristicForIdentifier(
         peripheral,
-        characteristicIdentifier,
+        characteristic._id,
         transactionId,
       );
 }

--- a/lib/internal/managers_for_classes.dart
+++ b/lib/internal/managers_for_classes.dart
@@ -80,13 +80,13 @@ abstract class ManagerForService {
 abstract class ManagerForCharacteristic {
   Future<Uint8List> readCharacteristicForIdentifier(
     Peripheral peripheral,
-    int characteristicIdentifier,
+    InternalCharacteristic characteristic,
     String transactionId,
   );
 
   Future<void> writeCharacteristicForIdentifier(
     Peripheral peripheral,
-    int characteristicIdentifier,
+    InternalCharacteristic characteristic,
     Uint8List bytes,
     bool withResponse,
     String transactionId,
@@ -94,7 +94,7 @@ abstract class ManagerForCharacteristic {
 
   Stream<Uint8List> monitorCharacteristicForIdentifier(
     Peripheral peripheral,
-    int characteristicIdentifier,
+    InternalCharacteristic characteristic,
     String transactionId,
   );
 }


### PR DESCRIPTION
I have not encountered a problem with omitting some initial events (for instance scan results or events from characteristics monitoring). I've been testing a lot of scenarios trying to invoke scanning start after the native side subscribes to it but the only way I could achieve that was by delaying the "invokeMethod" in onListen callback in returning stream.