### PR TITLE
[iOS][Blemulator][fix] Pass argument to startDeviceScan

### DIFF
--- a/ios/Classes/Blemulator/Bridging/DartMethodCaller.m
+++ b/ios/Classes/Blemulator/Bridging/DartMethodCaller.m
@@ -37,8 +37,9 @@ typedef void (^SuccessHandler)(id _Nullable result);
 // MARK: - Methods - Scanning
 
 - (void)startDeviceScan {
+    NSDictionary<NSString *,id> *arguments = [[NSDictionary alloc] init];
     [self.dartMethodChannel invokeMethod:DART_METHOD_NAME_START_DEVICE_SCAN
-                               arguments:nil
+                               arguments:arguments
                                   result:[self simpleInvokeMethodResultHandlerForMethod:DART_METHOD_NAME_START_DEVICE_SCAN]];
 }
 


### PR DESCRIPTION
Because flutter implementation has changed it is required to pass an arguments to startDeviceScan that is not null. Created an empty NSDictionary for that purpose for now.