### PR TITLE
Add NSBluetoothAlwaysUsageDescription to Info.plist in example app

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>App would like to use bluetooth for communication purposes</string>
 </dict>
 </plist>


### PR DESCRIPTION
NSBluetoothAlwaysUsageDescription key is required in Info.plist with deployment target below iOS 13 when trying to build using Xcode 11.