### PR TITLE
Emphasize that "createClient()" is async

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For more informations, see [REFERENCE](https://github.com/Polidea/FlutterBleLib/
 ### Initialising
 ```dart
 BleManager bleManager = BleManager();
-bleManager.createClient(); //ready to go!
+await bleManager.createClient(); //ready to go!
 // your peripheral logic
 bleManager.destroyClient(); //remember to release native resources when you're done!
 ```


### PR DESCRIPTION
I wasn't aware that `createClient()` method is asnyc, so I was getting wrong Bluetooth state when checking it too early. I think adding `await` in this code snippet makes it all clear now and the comment `// ready to go!` is finally true. 😄