### PR TITLE
Fix incorrectly implemented method on Android

### DIFF
--- a/android/src/main/java/com/polidea/flutter_ble_lib/MultiCharacteristicsResponse.java
+++ b/android/src/main/java/com/polidea/flutter_ble_lib/MultiCharacteristicsResponse.java
@@ -4,21 +4,34 @@ import com.polidea.multiplatformbleadapter.Characteristic;
 import com.polidea.multiplatformbleadapter.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 public class MultiCharacteristicsResponse {
     private final List<Characteristic> characteristics;
-    private Service service;
+    private int serviceId;
+    private UUID serviceUuid;
 
     public MultiCharacteristicsResponse(List<Characteristic> characteristics, Service service) {
         this.characteristics = characteristics;
-        this.service = service;
+        this.serviceId = service.getId();
+        this.serviceUuid = service.getUuid();
+    }
+
+    public MultiCharacteristicsResponse(List<Characteristic> characteristics, int serviceId, UUID serviceUuid) {
+        this.characteristics = characteristics;
+        this.serviceId = serviceId;
+        this.serviceUuid = serviceUuid;
     }
 
     public List<Characteristic> getCharacteristics() {
         return characteristics;
     }
 
-    public Service getService() {
-        return service;
+    public int getServiceId() {
+        return serviceId;
+    }
+
+    public UUID getServiceUuid() {
+        return serviceUuid;
     }
 }

--- a/android/src/main/java/com/polidea/flutter_ble_lib/converter/MultiCharacteristicsResponseJsonConverter.java
+++ b/android/src/main/java/com/polidea/flutter_ble_lib/converter/MultiCharacteristicsResponseJsonConverter.java
@@ -18,8 +18,8 @@ public class MultiCharacteristicsResponseJsonConverter implements JsonConverter<
     public String toJson(MultiCharacteristicsResponse characteristicsResponse) throws JSONException {
         JSONObject jsonObject = new JSONObject();
 
-        jsonObject.put(Metadata.UUID, characteristicsResponse.getService().getUuid());
-        jsonObject.put(Metadata.ID, characteristicsResponse.getService().getId());
+        jsonObject.put(Metadata.UUID, characteristicsResponse.getServiceUuid());
+        jsonObject.put(Metadata.ID, characteristicsResponse.getServiceId());
 
         JSONArray jsonArray = new CharacteristicJsonConverter().toJsonArray(characteristicsResponse.getCharacteristics());
 

--- a/android/src/main/java/com/polidea/flutter_ble_lib/delegate/DiscoveryDelegate.java
+++ b/android/src/main/java/com/polidea/flutter_ble_lib/delegate/DiscoveryDelegate.java
@@ -135,22 +135,24 @@ public class DiscoveryDelegate extends CallDelegate {
 
     private void getCharacteristics(String deviceId, final String serviceUuid, final MethodChannel.Result result) {
         try {
-            List<Service> services = adapter.getServicesForDevice(deviceId);
-            Service foundService = null;
-            for (final Service service : services) {
-                if (service.getUuid().equals(UUID.fromString(serviceUuid))) {
-                    foundService = service;
-                    break;
-                }
+            List<Characteristic> characteristics = adapter.getCharacteristicsForDevice(deviceId, serviceUuid);
+
+            MultiCharacteristicsResponse characteristicsResponse;
+
+            if (characteristics.size() == 0) {
+                characteristicsResponse = new MultiCharacteristicsResponse(
+                        characteristics,
+                        -1,
+                        null
+                );
+            } else {
+                characteristicsResponse = new MultiCharacteristicsResponse(
+                        characteristics,
+                        characteristics.get(0).getServiceID(),
+                        characteristics.get(0).getServiceUUID()
+                );
             }
 
-            if (foundService == null) {
-                result.error("UnknownServiceException", "Service not found", "Unknown service UUID " + serviceUuid);
-                return;
-            }
-
-            List<Characteristic> characteristics = adapter.getCharacteristicsForService(foundService.getId());
-            MultiCharacteristicsResponse characteristicsResponse = new MultiCharacteristicsResponse(characteristics, foundService);
             String json = multiCharacteristicsResponseJsonConverter.toJson(characteristicsResponse);
             result.success(json);
         } catch (BleError error) {


### PR DESCRIPTION
@TomoLV will provide fix for the same issue on iOS

## Issue:
Retrieving characteristic for service UUID (not ID) was done by retrieving all services, matching service with requested UUID and then calling `getCharacteristicsForService(id)`. 
MBA has a method `getCharacteristicsForDevice(peripheralId, serviceUuid)` which was unused, thus creating more space for errors and risking inconsistency with BLEmulator or react-native-ble-plx.