### PR TITLE
Fix incorrectly implemented method on iOS

### DIFF
--- a/ios/Classes/FlutterBleLibPlugin.m
+++ b/ios/Classes/FlutterBleLibPlugin.m
@@ -282,10 +282,10 @@
 }
 
 - (void)characteristics:(FlutterMethodCall *)call result:(FlutterResult)result {
-    [_adapter servicesForDevice:call.arguments[ARGUMENT_KEY_DEVICE_IDENTIFIER]
-                        resolve:[self resolveForCharacteristics:result
-                                                    serviceUuid:call.arguments[ARGUMENT_KEY_SERVICE_UUID]]
-                         reject:[self rejectForFlutterResult:result]];
+    [_adapter characteristicsForDevice:call.arguments[ARGUMENT_KEY_DEVICE_IDENTIFIER]
+                       serviceUUID:call.arguments[ARGUMENT_KEY_SERVICE_UUID]
+                           resolve:[self resolveForCharacteristicsForService:result]
+                            reject:[self rejectForFlutterResult:result]];
 }
 
 - (void)descriptorsForDevice:(FlutterMethodCall *)call result:(FlutterResult)result {
@@ -559,33 +559,6 @@
 - (Resolve)resolveForDescriptors:(FlutterResult)result {
     return ^(NSArray *descriptorsArray) {
         result([DescriptorResponseConverter jsonStringFromMultipleDescriptorsResponse:descriptorsArray]);
-    };
-}
-
-- (Resolve)resolveForCharacteristics:(FlutterResult)result serviceUuid:(NSString *)serviceUuid {
-    return ^(NSArray *servicesArray) {
-
-        NSDictionary *matchingService = nil;
-        for (NSDictionary *service in [ServiceResponseConverter servicesFromServicesResponse:servicesArray]) {
-            if ([[service valueForKey:@"serviceUuid"] isEqualToString:serviceUuid]) {
-                matchingService = service;
-                break;
-            }
-        }
-
-        if (matchingService == nil) {
-            result([FlutterError errorWithCode:@"-1" message:@"Service not found" details:nil]);
-            return;
-        }
-
-        Resolve resolve = ^(NSArray* characteristicsArray) {
-            result([CharacteristicResponseConverter jsonStringFromCharacteristicsResponse:characteristicsArray
-                                                                                  service:matchingService]);
-        };
-
-        [_adapter characteristicsForService:[[matchingService valueForKey:@"serviceId"] doubleValue]
-                            resolve:resolve
-                             reject:[self rejectForFlutterResult:result]];
     };
 }
 

--- a/ios/Classes/FlutterBleLibPlugin.m
+++ b/ios/Classes/FlutterBleLibPlugin.m
@@ -284,7 +284,7 @@
 - (void)characteristics:(FlutterMethodCall *)call result:(FlutterResult)result {
     [_adapter characteristicsForDevice:call.arguments[ARGUMENT_KEY_DEVICE_IDENTIFIER]
                        serviceUUID:call.arguments[ARGUMENT_KEY_SERVICE_UUID]
-                           resolve:[self resolveForCharacteristicsForService:result]
+                           resolve:[self resolveForCharacteristics:result]
                             reject:[self rejectForFlutterResult:result]];
 }
 
@@ -553,6 +553,12 @@
 - (Resolve)resolveForCharacteristicsForService:(FlutterResult)result {
     return ^(NSArray *characteristicsArray) {
         result([CharacteristicResponseConverter jsonStringFromCharacteristicsResponse:characteristicsArray]);
+    };
+}
+
+- (Resolve)resolveForCharacteristics:(FlutterResult)result {
+    return ^(NSArray* characteristicsArray) {
+        result([CharacteristicResponseConverter jsonStringWithServiceFromCharacteristicsResponse:characteristicsArray]);
     };
 }
 

--- a/ios/Classes/ResponseConverter/CharacteristicResponseConverter.h
+++ b/ios/Classes/ResponseConverter/CharacteristicResponseConverter.h
@@ -5,8 +5,7 @@
 
 + (NSString *)jsonStringFromCharacteristicsResponse:(NSArray *)characteristicsResponse;
 
-+ (NSString *)jsonStringFromCharacteristicsResponse:(NSArray *)characteristicsResponse
-                                            service:(NSDictionary *)service;
++ (NSString *)jsonStringWithServiceFromCharacteristicsResponse:(NSArray *)characteristicsResponse;
 
 + (NSArray *)characteristicsFromCharacteristicResponse:(NSArray *)characteristicsResponse;
 

--- a/ios/Classes/ResponseConverter/CharacteristicResponseConverter.m
+++ b/ios/Classes/ResponseConverter/CharacteristicResponseConverter.m
@@ -38,11 +38,24 @@ const NSString *keyCharacteristics = @"characteristics";
     return [JSONStringifier jsonStringFromJSONObject:result];
 }
 
-+ (NSString *)jsonStringFromCharacteristicsResponse:(NSArray *)characteristicsResponse
-                                            service:(NSDictionary *)service {
-    NSMutableDictionary *result = [[NSMutableDictionary alloc] initWithDictionary:service];
-    [result setObject:[self characteristicsFromCharacteristicResponse:characteristicsResponse]
-               forKey:keyCharacteristics];
++ (NSString *)jsonStringWithServiceFromCharacteristicsResponse:(NSArray *)characteristicsResponse {
+    NSArray *characteristics = [self characteristicsFromCharacteristicResponse:characteristicsResponse];
+    double serviceId;
+    id serviceUuid;
+
+    if (characteristicsResponse.count == 0) {
+        serviceId = -1;
+        serviceUuid = [NSNull null];
+    } else {
+        serviceId = [[characteristicsResponse.firstObject objectForKey:CHARACTERISTIC_RESPONSE_SERVICE_ID] doubleValue];
+        serviceUuid = [characteristicsResponse.firstObject objectForKey:CHARACTERISTIC_RESPONSE_SERVICE_UUID];
+    }
+
+    NSDictionary *result = [[NSDictionary alloc] initWithObjectsAndKeys:
+                            characteristics, keyCharacteristics,
+                            serviceId, keyServiceID,
+                            serviceUuid, keyServiceUUID,
+                            nil];
     return [JSONStringifier jsonStringFromJSONObject:result];
 
 }

--- a/ios/Classes/ResponseConverter/CharacteristicResponseConverter.m
+++ b/ios/Classes/ResponseConverter/CharacteristicResponseConverter.m
@@ -40,14 +40,14 @@ const NSString *keyCharacteristics = @"characteristics";
 
 + (NSString *)jsonStringWithServiceFromCharacteristicsResponse:(NSArray *)characteristicsResponse {
     NSArray *characteristics = [self characteristicsFromCharacteristicResponse:characteristicsResponse];
-    double serviceId;
+    id serviceId;
     id serviceUuid;
 
     if (characteristicsResponse.count == 0) {
-        serviceId = -1;
+        serviceId = [NSNumber numberWithInt:-1];
         serviceUuid = [NSNull null];
     } else {
-        serviceId = [[characteristicsResponse.firstObject objectForKey:CHARACTERISTIC_RESPONSE_SERVICE_ID] doubleValue];
+        serviceId = [characteristicsResponse.firstObject objectForKey:CHARACTERISTIC_RESPONSE_SERVICE_ID];
         serviceUuid = [characteristicsResponse.firstObject objectForKey:CHARACTERISTIC_RESPONSE_SERVICE_UUID];
     }
 


### PR DESCRIPTION
Connected with #407.

During library implementation process, `characteristicsForDevice:serviceUUID` method was incorrectly implemented. As this was identified, the fix was needed to address the issue.

Now appropriate method of MultiplatformBLEAdapter is being called when `characteristicsForDevice:serviceUUID` is requested.