### PR TITLE
Example: handle Bluetooth permission on iOS

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -15,10 +15,11 @@
 *.iws
 .idea/
 
-# The .vscode folder contains launch configuration and tasks you configure in
-# VS Code which you may wish to be included in version control, so this line
-# is commented out by default.
-#.vscode/
+# Visual Studio Code related
+.classpath
+.project
+.settings/
+.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/
@@ -57,13 +58,14 @@
 **/ios/.generated/
 **/ios/Flutter/App.framework
 **/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
 **/ios/Flutter/Generated.xcconfig
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
-**/ios/Flutter/flutter_export_environment.sh
 
 # Exceptions to above rules.
 !**/ios/**/default.mode1v3

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -15,49 +15,67 @@ def parse_KV_file(file, separator='=')
   if !File.exists? file_abs_path
     return [];
   end
-  pods_ary = []
+  generated_key_values = {}
   skip_line_start_symbols = ["#", "/"]
-  File.foreach(file_abs_path) { |line|
-      next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-      plugin = line.split(pattern=separator)
-      if plugin.length == 2
-        podname = plugin[0].strip()
-        path = plugin[1].strip()
-        podpath = File.expand_path("#{path}", file_abs_path)
-        pods_ary.push({:name => podname, :path => podpath});
-      else
-        puts "Invalid plugin specification: #{line}"
-      end
-  }
-  return pods_ary
+  File.foreach(file_abs_path) do |line|
+    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
+    plugin = line.split(pattern=separator)
+    if plugin.length == 2
+      podname = plugin[0].strip()
+      path = plugin[1].strip()
+      podpath = File.expand_path("#{path}", file_abs_path)
+      generated_key_values[podname] = podpath
+    else
+      puts "Invalid plugin specification: #{line}"
+    end
+  end
+  generated_key_values
 end
 
 target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+  
+  # Flutter Pod
+
+  copied_flutter_dir = File.join(__dir__, 'Flutter')
+  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
+  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
+  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
+    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
+    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration.
+    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
+
+    generated_xcode_build_settings_path = File.join(copied_flutter_dir, 'Generated.xcconfig')
+    unless File.exist?(generated_xcode_build_settings_path)
+      raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+    end
+    generated_xcode_build_settings = parse_KV_file(generated_xcode_build_settings_path)
+    cached_framework_dir = generated_xcode_build_settings['FLUTTER_FRAMEWORK_DIR'];
+
+    unless File.exist?(copied_framework_path)
+      FileUtils.cp_r(File.join(cached_framework_dir, 'Flutter.framework'), copied_flutter_dir)
+    end
+    unless File.exist?(copied_podspec_path)
+      FileUtils.cp(File.join(cached_framework_dir, 'Flutter.podspec'), copied_flutter_dir)
+    end
+  end
+
+  # Keep pod path relative so it can be checked into Podfile.lock.
+  pod 'Flutter', :path => 'Flutter'
+
+  # Plugin Pods
+
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
   system('rm -rf .symlinks')
   system('mkdir -p .symlinks/plugins')
-
-  # Flutter Pods
-  generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
-  if generated_xcode_build_settings.empty?
-    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first."
-  end
-  generated_xcode_build_settings.map { |p|
-    if p[:name] == 'FLUTTER_FRAMEWORK_DIR'
-      symlink = File.join('.symlinks', 'flutter')
-      File.symlink(File.dirname(p[:path]), symlink)
-      pod 'Flutter', :path => File.join(symlink, File.basename(p[:path]))
-    end
-  }
-
-  # Plugin Pods
   plugin_pods = parse_KV_file('../.flutter-plugins')
-  plugin_pods.map { |p|
-    symlink = File.join('.symlinks', 'plugins', p[:name])
-    File.symlink(p[:path], symlink)
-    pod p[:name], :path => File.join(symlink, 'ios')
-  }
+  plugin_pods.each do |name, path|
+    symlink = File.join('.symlinks', 'plugins', name)
+    File.symlink(path, symlink)
+    pod name, :path => File.join(symlink, 'ios')
+  end
 end
 
 # Prevent Cocoapods from embedding a second Flutter framework and causing an error with the new Xcode build system.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
-  - Flutter (from `.symlinks/flutter/ios`)
+  - Flutter (from `Flutter`)
   - flutter_ble_lib (from `.symlinks/plugins/flutter_ble_lib/ios`)
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
 
@@ -18,7 +18,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Flutter:
-    :path: ".symlinks/flutter/ios"
+    :path: Flutter
   flutter_ble_lib:
     :path: ".symlinks/plugins/flutter_ble_lib/ios"
   permission_handler:
@@ -30,6 +30,6 @@ SPEC CHECKSUMS:
   MultiplatformBleAdapter: edd1e768925ab61637cb178bd465eb12952ec981
   permission_handler: 40520ab8ad1bb78a282b832464e995ec87f77ec6
 
-PODFILE CHECKSUM: 7fb83752f59ead6285236625b82473f90b1cb932
+PODFILE CHECKSUM: 1b66dae606f75376c5f2135a8290850eeb09ae83
 
 COCOAPODS: 1.8.3

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		1F98025F8F407F461CB357DF /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E99B52135973B0C19BFDEF7 /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -20,7 +21,6 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		FCCECD7558D2E2090C6C8496 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E0EB5FDC45BCE895CE667840 /* libPods-Runner.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -39,6 +39,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0E99B52135973B0C19BFDEF7 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		142FC6F382131B8002E818AB /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
@@ -60,7 +61,6 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E0EB5FDC45BCE895CE667840 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,7 +70,7 @@
 			files = (
 				9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */,
 				3B80C3941E831B6300D905FE /* App.framework in Frameworks */,
-				FCCECD7558D2E2090C6C8496 /* libPods-Runner.a in Frameworks */,
+				1F98025F8F407F461CB357DF /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -148,7 +148,7 @@
 		B683159A18784524E61A2269 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E0EB5FDC45BCE895CE667840 /* libPods-Runner.a */,
+				0E99B52135973B0C19BFDEF7 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/example/lib/devices_list/devices_bloc.dart
+++ b/example/lib/devices_list/devices_bloc.dart
@@ -97,11 +97,15 @@ class DevicesBloc {
 
   Future<void> _waitForBluetoothPoweredOn() async {
     Completer completer = Completer();
-    _bleManager
+    StreamSubscription<BluetoothState> subscription;
+    subscription = _bleManager
         .observeBluetoothState(emitCurrentValue: true)
-        .listen((bluetoothState) {
-      if (bluetoothState == BluetoothState.POWERED_ON && !completer.isCompleted)
+        .listen((bluetoothState) async {
+      if (bluetoothState == BluetoothState.POWERED_ON &&
+          !completer.isCompleted) {
+        await subscription.cancel();
         completer.complete();
+      }
     });
     return completer.future;
   }

--- a/example/lib/devices_list/devices_bloc.dart
+++ b/example/lib/devices_list/devices_bloc.dart
@@ -77,11 +77,6 @@ class DevicesBloc {
   }
 
   Future<void> _checkPermissions() async {
-    _bleManager
-        .observeBluetoothState(emitCurrentValue: true)
-        .listen((bluetoothState) {
-      if (bluetoothState == BluetoothState.POWERED_ON) {}
-    });
     if (Platform.isAndroid) {
       var permissionStatus = await PermissionHandler()
           .requestPermissions([PermissionGroup.location]);

--- a/example/lib/devices_list/devices_bloc.dart
+++ b/example/lib/devices_list/devices_bloc.dart
@@ -59,8 +59,8 @@ class DevicesBloc {
             })
         .catchError((e) => Fimber.d("Couldn't create BLE client", ex: e))
         .then((_) => _checkPermissions())
-        .then((_) => _waitForBluetoothPoweredOn())
         .catchError((e) => Fimber.d("Permission check error", ex: e))
+        .then((_) => _waitForBluetoothPoweredOn())
         .then((_) => _startScan());
 
     if (_visibleDevicesController.isClosed) {

--- a/example/lib/devices_list/devices_bloc.dart
+++ b/example/lib/devices_list/devices_bloc.dart
@@ -92,9 +92,10 @@ class DevicesBloc {
         return Future.error(Exception("Location permission not granted"));
       }
     } else if (Platform.isIOS) {
-      /// On iOS the user will be asked to allow Bluetooth permission by
+      /// On iOS the user will be asked to allow Bluetooth access by
       /// the system. Once it is granted, the Bluetooth state will change from
-      /// UNKNOWN to POWERED_ON.
+      /// UNKNOWN to POWERED_ON. The following function will block the thread
+      /// until it happens.
       await _waitForBluetoothPoweredOn();
     }
   }

--- a/example/lib/devices_list/devices_bloc.dart
+++ b/example/lib/devices_list/devices_bloc.dart
@@ -86,13 +86,13 @@ class DevicesBloc {
       if (_locationPermissionStatus != PermissionStatus.granted) {
         return Future.error(Exception("Location permission not granted"));
       }
-    } else if (Platform.isIOS) {
-      /// On iOS the user will be asked to allow Bluetooth access by
-      /// the system. Once it is granted, the Bluetooth state will change from
-      /// UNKNOWN to POWERED_ON. The following function will block the thread
-      /// until it happens.
-      await _waitForBluetoothPoweredOn();
     }
+
+    /// On iOS the user will be asked to allow Bluetooth access by
+    /// the system. Once it is granted, the Bluetooth state will change from
+    /// UNKNOWN to POWERED_ON. The following function will block the thread
+    /// until it happens.
+    await _waitForBluetoothPoweredOn();
   }
 
   Future<void> _waitForBluetoothPoweredOn() async {

--- a/example/lib/devices_list/devices_bloc.dart
+++ b/example/lib/devices_list/devices_bloc.dart
@@ -59,6 +59,7 @@ class DevicesBloc {
             })
         .catchError((e) => Fimber.d("Couldn't create BLE client", ex: e))
         .then((_) => _checkPermissions())
+        .then((_) => _waitForBluetoothPoweredOn())
         .catchError((e) => Fimber.d("Permission check error", ex: e))
         .then((_) => _startScan());
 
@@ -87,12 +88,6 @@ class DevicesBloc {
         return Future.error(Exception("Location permission not granted"));
       }
     }
-
-    /// On iOS the user will be asked to allow Bluetooth access by
-    /// the system. Once it is granted, the Bluetooth state will change from
-    /// UNKNOWN to POWERED_ON. The following function will block the thread
-    /// until it happens.
-    await _waitForBluetoothPoweredOn();
   }
 
   Future<void> _waitForBluetoothPoweredOn() async {


### PR DESCRIPTION
When launching the app on iOS for the first time, the system asks for Bluetooth permission. However, the example app ignores it and tries to scan anyway, so it won't work.

This PR fixes this problem by observing Bluetooth state and waiting for `POWERED_ON` value. 

There is also an updated version of Podfile. I got warning when building the app that it needs to be updated for the new version of Flutter:

```
Warning: Podfile is out of date
  This can cause a mismatched version of Flutter to be embedded in your app, which may result in App Store submission rejection or crashes.
  If you have local Podfile edits you would like to keep, see https://github.com/flutter/flutter/issues/24641 for instructions.
To regenerate the Podfile, run:
  rm ios/Podfile
```

 So I removed it and the new auto-generated version is here.

I have also updated .gitignore by adding `Flutter.podspec` to ignore.