### PR TITLE
[iOS] Fix base64 string encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2
+
+* Fix issue with invalid characteristic value base64 coding when performing characteristic operations on iOS
+
 ## 2.2.1
 
 * Hide private APIs

--- a/ios/Classes/FlutterBleLibPlugin.m
+++ b/ios/Classes/FlutterBleLibPlugin.m
@@ -607,7 +607,7 @@
 }
 
 - (NSString *)base64encodedStringFromBytes:(FlutterStandardTypedData *)bytes {
-    return [bytes.data base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+    return [bytes.data base64EncodedStringWithOptions:0];
 }
 
 @end


### PR DESCRIPTION
Fix issue with invalid characteristic value base64 coding when performing characteristic operations on iOS.

Base64 encoding was implemented wrongly with `NSDataBase64Encoding64CharacterLineLength` flag, which resulted in additional new line characters being added to the result string.