### PR TITLE
Fix capitalization style for UUID and constant names

### DIFF
--- a/lib/ble_manager.dart
+++ b/lib/ble_manager.dart
@@ -42,7 +42,7 @@ abstract class BleManager {
   }
 
   /// Cancels transaction's return, resulting in [BleError] with
-  /// [BleError.errorCode] set to [BleErrorCode.OperationCancelled] being returned
+  /// [BleError.errorCode] set to [BleErrorCode.operationCancelled] being returned
   /// from transaction's Future.
   ///
   /// The operation might be cancelled if it hadn't yet started or be run

--- a/lib/characteristic.dart
+++ b/lib/characteristic.dart
@@ -36,6 +36,7 @@ class Characteristic extends InternalCharacteristic {
 
   /// True if this characteristic can be monitored via notifications.
   bool isNotifiable;
+
   /// True if this characteristic can be monitored via indications.
   bool isIndicatable;
 
@@ -70,14 +71,14 @@ class Characteristic extends InternalCharacteristic {
   /// [isWritableWithoutResponse] is `true` and argument [withResponse] is
   /// set accordingly.
   Future<void> write(
-    Uint8List bytes,
+    Uint8List value,
     bool withResponse, {
     String transactionId,
   }) =>
       _manager.writeCharacteristicForIdentifier(
         service.peripheral,
         this,
-        bytes,
+        value,
         withResponse,
         transactionId ?? TransactionIdGenerator.getNextId(),
       );

--- a/lib/error/ble_error.dart
+++ b/lib/error/ble_error.dart
@@ -1,15 +1,15 @@
 part of flutter_ble_lib;
 
 abstract class _BleErrorMetadata {
-  static const String ERROR_CODE = "errorCode";
-  static const String ATT_ERROR_CODE = "attErrorCode";
-  static const String ANDROID_ERROR_CODE = "androidErrorCode";
-  static const String REASON = "reason";
-  static const String DEVICE_ID = "deviceID";
-  static const String SERVICE_UUID = "serviceUUID";
-  static const String CHARACTERISTIC_UUID = "characteristicUUID";
-  static const String DESCRIPTOR_UUID = "descriptorUUID";
-  static const String INTERNAL_MESSAGE = "internalMessage";
+  static const String errorCode = "errorCode";
+  static const String attErrorCode = "attErrorCode";
+  static const String androidErrorCode = "androidErrorCode";
+  static const String reason = "reason";
+  static const String deviceId = "deviceID";
+  static const String serviceUuid = "serviceUUID";
+  static const String characteristicUuid = "characteristicUUID";
+  static const String descriptorUuid = "descriptorUUID";
+  static const String internalMessage = "internalMessage";
 }
 
 class BleError {
@@ -20,21 +20,21 @@ class BleError {
   String reason;
 
   String deviceID;
-  String serviceUUID;
-  String characteristicUUID;
-  String descriptorUUID;
+  String serviceUuid;
+  String characteristicUuid;
+  String descriptorUuid;
   String internalMessage;
 
   BleError.fromJson(Map<String, dynamic> json)
-      : errorCode = BleErrorCode(json[_BleErrorMetadata.ERROR_CODE]),
-        attErrorCode = json[_BleErrorMetadata.ATT_ERROR_CODE],
-        androidErrorCode = json[_BleErrorMetadata.ANDROID_ERROR_CODE],
-        reason = json[_BleErrorMetadata.REASON],
-        deviceID = json[_BleErrorMetadata.DEVICE_ID],
-        serviceUUID = json[_BleErrorMetadata.SERVICE_UUID],
-        characteristicUUID = json[_BleErrorMetadata.CHARACTERISTIC_UUID],
-        descriptorUUID = json[_BleErrorMetadata.DESCRIPTOR_UUID],
-        internalMessage = json[_BleErrorMetadata.INTERNAL_MESSAGE];
+      : errorCode = BleErrorCode(json[_BleErrorMetadata.errorCode]),
+        attErrorCode = json[_BleErrorMetadata.attErrorCode],
+        androidErrorCode = json[_BleErrorMetadata.androidErrorCode],
+        reason = json[_BleErrorMetadata.reason],
+        deviceID = json[_BleErrorMetadata.deviceId],
+        serviceUuid = json[_BleErrorMetadata.serviceUuid],
+        characteristicUuid = json[_BleErrorMetadata.characteristicUuid],
+        descriptorUuid = json[_BleErrorMetadata.descriptorUuid],
+        internalMessage = json[_BleErrorMetadata.internalMessage];
 
   @override
   String toString() => "BleError ("
@@ -45,57 +45,57 @@ class BleError {
       "reason: $reason, "
       "internal message: $internalMessage, "
       "device ID: $deviceID, "
-      "service UUID: $serviceUUID, "
-      "characteristic UUID: $characteristicUUID, "
-      "descriptor UUID: $descriptorUUID)";
+      "service UUID: $serviceUuid, "
+      "characteristic UUID: $characteristicUuid, "
+      "descriptor UUID: $descriptorUuid)";
 }
 
 class BleErrorCode {
-  static const int UnknownError = 0;
-  static const int BluetoothManagerDestroyed = 1;
-  static const int OperationCancelled = 2;
-  static const int OperationTimedOut = 3;
-  static const int OperationStartFailed = 4;
-  static const int InvalidIdentifiers = 5;
+  static const int unknownError = 0;
+  static const int bluetoothManagerDestroyed = 1;
+  static const int operationCancelled = 2;
+  static const int operationTimedOut = 3;
+  static const int operationStartFailed = 4;
+  static const int invalidIdentifiers = 5;
 
-  static const int BluetoothUnsupported = 100;
-  static const int BluetoothUnauthorized = 101;
-  static const int BluetoothPoweredOff = 102;
-  static const int BluetoothInUnknownState = 103;
-  static const int BluetoothResetting = 104;
-  static const int BluetoothStateChangeFailed = 105;
+  static const int bluetoothUnsupported = 100;
+  static const int bluetoothUnauthorized = 101;
+  static const int bluetoothPoweredOff = 102;
+  static const int bluetoothInUnknownState = 103;
+  static const int bluetoothResetting = 104;
+  static const int bluetoothStateChangeFailed = 105;
 
-  static const int DeviceConnectionFailed = 200;
-  static const int DeviceDisconnected = 201;
-  static const int DeviceRSSIReadFailed = 202;
-  static const int DeviceAlreadyConnected = 203;
-  static const int DeviceNotFound = 204;
-  static const int DeviceNotConnected = 205;
-  static const int DeviceMTUChangeFailed = 206;
+  static const int deviceConnectionFailed = 200;
+  static const int deviceDisconnected = 201;
+  static const int deviceRSSIReadFailed = 202;
+  static const int deviceAlreadyConnected = 203;
+  static const int deviceNotFound = 204;
+  static const int deviceNotConnected = 205;
+  static const int deviceMTUChangeFailed = 206;
 
-  static const int ServicesDiscoveryFailed = 300;
-  static const int IncludedServicesDiscoveryFailed = 301;
-  static const int ServiceNotFound = 302;
-  static const int ServicesNotDiscovered = 303;
+  static const int servicesDiscoveryFailed = 300;
+  static const int includedServicesDiscoveryFailed = 301;
+  static const int serviceNotFound = 302;
+  static const int servicesNotDiscovered = 303;
 
-  static const int CharacteristicsDiscoveryFailed = 400;
-  static const int CharacteristicWriteFailed = 401;
-  static const int CharacteristicReadFailed = 402;
-  static const int CharacteristicNotifyChangeFailed = 403;
-  static const int CharacteristicNotFound = 404;
-  static const int CharacteristicsNotDiscovered = 405;
-  static const int CharacteristicInvalidDataFormat = 406;
+  static const int characteristicsDiscoveryFailed = 400;
+  static const int characteristicWriteFailed = 401;
+  static const int characteristicReadFailed = 402;
+  static const int characteristicNotifyChangeFailed = 403;
+  static const int characteristicNotFound = 404;
+  static const int characteristicsNotDiscovered = 405;
+  static const int characteristicInvalidDataFormat = 406;
 
-  static const int DescriptorsDiscoveryFailed = 500;
-  static const int DescriptorWriteFailed = 501;
-  static const int DescriptorReadFailed = 502;
-  static const int DescriptorNotFound = 503;
-  static const int DescriptorsNotDiscovered = 504;
-  static const int DescriptorInvalidDataFormat = 505;
-  static const int DescriptorWriteNotAllowed = 506;
+  static const int descriptorsDiscoveryFailed = 500;
+  static const int descriptorWriteFailed = 501;
+  static const int descriptorReadFailed = 502;
+  static const int descriptorNotFound = 503;
+  static const int descriptorsNotDiscovered = 504;
+  static const int descriptorInvalidDataFormat = 505;
+  static const int descriptorWriteNotAllowed = 506;
 
-  static const int ScanStartFailed = 600;
-  static const int LocationServicesDisabled = 601;
+  static const int scanStartFailed = 600;
+  static const int locationServicesDisabled = 601;
 
   int value;
 

--- a/lib/peripheral.dart
+++ b/lib/peripheral.dart
@@ -122,39 +122,39 @@ class Peripheral {
 
   /// Reads value of [Characteristic] matching specified UUIDs.
   ///
-  /// Returns value of characteristic with [characteristicUUID] for service with
-  /// [serviceUUID]. Optional [transactionId] could be used to cancel operation.
+  /// Returns value of characteristic with [characteristicUuid] for service with
+  /// [serviceUuid]. Optional [transactionId] could be used to cancel operation.
   ///
   /// Will result in error if discovery was not done during this connection.
   Future<CharacteristicWithValue> readCharacteristic(
-    String serviceUUID,
-    String characteristicUUID, {
+    String serviceUuid,
+    String characteristicUuid, {
     String transactionId,
   }) =>
       _manager.readCharacteristicForDevice(
         this,
-        serviceUUID,
-        characteristicUUID,
+        serviceUuid,
+        characteristicUuid,
         transactionId ?? TransactionIdGenerator.getNextId(),
       );
 
   /// Writes value of [Characteristic] matching specified UUIDs.
   ///
-  /// Writes [value] to characteristic with [characteristicUUID] for service with
-  /// [serviceUUID]. Optional [transactionId] could be used to cancel operation.
+  /// Writes [value] to characteristic with [characteristicUuid] for service with
+  /// [serviceUuid]. Optional [transactionId] could be used to cancel operation.
   ///
   /// Will result in error if discovery was not done during this connection.
   Future<Characteristic> writeCharacteristic(
-    String serviceUUID,
-    String characteristicUUID,
+    String serviceUuid,
+    String characteristicUuid,
     Uint8List value,
     bool withResponse, {
     String transactionId,
   }) =>
       _manager.writeCharacteristicForDevice(
         this,
-        serviceUUID,
-        characteristicUUID,
+        serviceUuid,
+        characteristicUuid,
         value,
         withResponse,
         transactionId ?? TransactionIdGenerator.getNextId(),
@@ -221,21 +221,21 @@ class Peripheral {
   /// matching specified UUIDs.
   ///
   /// Emits [CharacteristicWithValue] for every observed change of the
-  /// characteristic specified by [serviceUUID] and [characteristicUUID]
+  /// characteristic specified by [serviceUuid] and [characteristicUuid]
   /// If notifications are enabled they will be used in favour of indications.
   /// Optional [transactionId] could be used to cancel operation. Unsubscribing
   /// from the stream cancels monitoring.
   ///
   /// Will result in error if discovery was not done during this connection.
   Stream<CharacteristicWithValue> monitorCharacteristic(
-    String serviceUUID,
-    String characteristicUUID, {
+    String serviceUuid,
+    String characteristicUuid, {
     String transactionId,
   }) =>
       _manager.monitorCharacteristicForDevice(
         this,
-        serviceUUID,
-        characteristicUUID,
+        serviceUuid,
+        characteristicUuid,
         transactionId ?? TransactionIdGenerator.getNextId(),
       );
 

--- a/lib/scan_result.dart
+++ b/lib/scan_result.dart
@@ -6,12 +6,12 @@ abstract class _ScanResultMetadata {
   static const String rssi = "rssi";
   static const String manufacturerData = "manufacturerData";
   static const String serviceData = "serviceData";
-  static const String serviceUuids = "serviceUuids";
+  static const String serviceUuids = "serviceUUIDs";
   static const String localName = "localName";
   static const String txPowerLevel = "txPowerLevel";
-  static const String solicitedServiceUuids = "solicitedServiceUuids";
+  static const String solicitedServiceUuids = "solicitedServiceUUIDs";
   static const String isConnectable = "isConnectable";
-  static const String overflowServiceUuids = "overflowServiceUuids";
+  static const String overflowServiceUuids = "overflowServiceUUIDs";
 }
 
 /// A scan result emitted by the scanning operation, containing [Peripheral] and [AdvertisementData].

--- a/lib/scan_result.dart
+++ b/lib/scan_result.dart
@@ -6,12 +6,12 @@ abstract class _ScanResultMetadata {
   static const String rssi = "rssi";
   static const String manufacturerData = "manufacturerData";
   static const String serviceData = "serviceData";
-  static const String serviceUuids = "serviceUUIDs";
+  static const String serviceUuids = "serviceUuids";
   static const String localName = "localName";
   static const String txPowerLevel = "txPowerLevel";
-  static const String solicitedServiceUuids = "solicitedServiceUUIDs";
+  static const String solicitedServiceUuids = "solicitedServiceUuids";
   static const String isConnectable = "isConnectable";
-  static const String overflowServiceUuids = "overflowServiceUUIDs";
+  static const String overflowServiceUuids = "overflowServiceUuids";
 }
 
 /// A scan result emitted by the scanning operation, containing [Peripheral] and [AdvertisementData].

--- a/lib/scan_result.dart
+++ b/lib/scan_result.dart
@@ -20,11 +20,12 @@ class ScanResult {
 
   /// Signal strength of the peripheral in dBm.
   int rssi;
+
   /// An indicator whether the peripheral is connectable (iOS only).
   bool isConnectable;
 
   /// A list of UUIDs found in the overflow area of the advertisement data (iOS only).
-  List<String> overflowServiceUUIDs;
+  List<String> overflowServiceUuids;
 
   /// A packet of data advertised by the peripheral.
   AdvertisementData advertisementData;
@@ -33,7 +34,7 @@ class ScanResult {
       : peripheral = Peripheral.fromJson(json, manager),
         rssi = json[_ScanResultMetadata.rssi],
         isConnectable = json[_ScanResultMetadata.isConnectable],
-        overflowServiceUUIDs = json[_ScanResultMetadata.overflowServiceUuids],
+        overflowServiceUuids = json[_ScanResultMetadata.overflowServiceUuids],
         advertisementData = AdvertisementData._fromJson(json);
 }
 
@@ -47,7 +48,7 @@ class AdvertisementData {
   Map<String, Uint8List> serviceData;
 
   /// A list of service UUIDs.
-  List<String> serviceUUIDs;
+  List<String> serviceUuids;
 
   /// The local name of the [Peripheral]. Might be different than
   /// [Peripheral.name].
@@ -57,18 +58,18 @@ class AdvertisementData {
   int txPowerLevel;
 
   /// A list of solicited service UUIDs.
-  List<String> solicitedServiceUUIDs;
+  List<String> solicitedServiceUuids;
 
   AdvertisementData._fromJson(Map<String, dynamic> json)
       : manufacturerData =
             _decodeBase64OrNull(json[_ScanResultMetadata.manufacturerData]),
         serviceData =
             _getServiceDataOrNull(json[_ScanResultMetadata.serviceData]),
-        serviceUUIDs =
+        serviceUuids =
             _mapToListOfStringsOrNull(json[_ScanResultMetadata.serviceUuids]),
         localName = json[_ScanResultMetadata.localName],
         txPowerLevel = json[_ScanResultMetadata.txPowerLevel],
-        solicitedServiceUUIDs = _mapToListOfStringsOrNull(
+        solicitedServiceUuids = _mapToListOfStringsOrNull(
             json[_ScanResultMetadata.solicitedServiceUuids]);
 
   static Map<String, Uint8List> _getServiceDataOrNull(

--- a/lib/service.dart
+++ b/lib/service.dart
@@ -30,7 +30,7 @@ class Service extends InternalService {
       _manager.characteristicsForService(this);
 
   /// Writes the [value] to the [Characteristic] identified by
-  /// [characteristicUUID].
+  /// [characteristicUuid].
   ///
   /// It returns a [Future] that completes with the [Characteristic] for the
   /// convenience of chaining operations.
@@ -40,7 +40,7 @@ class Service extends InternalService {
   /// [Characteristic.isWritableWithoutResponse] is `true` and
   /// [withResponse] is specified accordingly can be written to.
   Future<Characteristic> writeCharacteristic(
-    String characteristicUUID,
+    String characteristicUuid,
     Uint8List value,
     bool withResponse, {
     String transactionId,
@@ -48,30 +48,30 @@ class Service extends InternalService {
       _manager.writeCharacteristicForService(
           peripheral,
           this,
-          characteristicUUID,
+          characteristicUuid,
           value,
           withResponse,
           transactionId ?? TransactionIdGenerator.getNextId());
 
-  /// Reads the value of a [Characteristic] identified by [characteristicUUID].
+  /// Reads the value of a [Characteristic] identified by [characteristicUuid].
   ///
   /// It returns a [Future] that completes with [CharacteristicWithValue],
   /// which is just a [Characteristic] but with an additonal `value`
   /// property of type [Uint8List]. Only [Characteristic] where
   /// [Characteristic.isReadable] is `true` can be read.
   Future<CharacteristicWithValue> readCharacteristic(
-    String characteristicUUID, {
+    String characteristicUuid, {
     String transactionId,
   }) =>
       _manager.readCharacteristicForService(
         peripheral,
         this,
-        characteristicUUID,
+        characteristicUuid,
         transactionId ?? TransactionIdGenerator.getNextId(),
       );
 
   /// Returns a [Stream] of values emitted by a [Characteristic] identified by
-  /// [characteristicUUID].
+  /// [characteristicUuid].
   ///
   /// Just like [readCharacteristic()] method, values are emitted as
   /// [CharacteristicWithValue] objects, which are the same as [Characteristic]
@@ -79,13 +79,13 @@ class Service extends InternalService {
   /// [Characteristic] where [Characteristic.isNotifiable] is `true` can be
   /// monitored.
   Stream<CharacteristicWithValue> monitorCharacteristic(
-    String characteristicUUID, {
+    String characteristicUuid, {
     String transactionId,
   }) =>
       _manager.monitorCharacteristicForService(
         peripheral,
         this,
-        characteristicUUID,
+        characteristicUuid,
         transactionId ?? TransactionIdGenerator.getNextId(),
       );
 

--- a/lib/src/_managers_for_classes.dart
+++ b/lib/src/_managers_for_classes.dart
@@ -56,7 +56,7 @@ abstract class ManagerForPeripheral {
       Peripheral peripheral,
       String serviceUuid,
       String characteristicUuid,
-      Uint8List bytes,
+      Uint8List value,
       bool withResponse,
       String transactionId);
 
@@ -86,7 +86,7 @@ abstract class ManagerForPeripheral {
     String serviceUuid,
     String characteristicUuid,
     String descriptorUuid,
-    Uint8List bytes,
+    Uint8List value,
     String transactionId,
   );
 }
@@ -105,7 +105,7 @@ abstract class ManagerForService {
     Peripheral peripheral,
     InternalService service,
     String characteristicUuid,
-    Uint8List bytes,
+    Uint8List value,
     bool withResponse,
     String transactionId,
   );
@@ -133,7 +133,7 @@ abstract class ManagerForService {
     Service service,
     String characteristicUuid,
     String descriptorUuid,
-    Uint8List bytes,
+    Uint8List value,
     String transactionId,
   );
 }
@@ -148,7 +148,7 @@ abstract class ManagerForCharacteristic {
   Future<void> writeCharacteristicForIdentifier(
     Peripheral peripheral,
     InternalCharacteristic characteristic,
-    Uint8List bytes,
+    Uint8List value,
     bool withResponse,
     String transactionId,
   );
@@ -185,7 +185,7 @@ abstract class ManagerForDescriptor {
 
   Future<void> writeDescriptorForIdentifier(
     Descriptor descriptor,
-    Uint8List bytes,
+    Uint8List value,
     String transactionId,
   );
 }

--- a/lib/src/_managers_for_classes.dart
+++ b/lib/src/_managers_for_classes.dart
@@ -48,22 +48,22 @@ abstract class ManagerForPeripheral {
   Future<CharacteristicWithValue> readCharacteristicForDevice(
     Peripheral peripheral,
     String serviceUuid,
-    String characteristicUUID,
+    String characteristicUuid,
     String transactionId,
   );
 
   Future<Characteristic> writeCharacteristicForDevice(
       Peripheral peripheral,
-      String serviceUUID,
-      String characteristicUUID,
+      String serviceUuid,
+      String characteristicUuid,
       Uint8List bytes,
       bool withResponse,
       String transactionId);
 
   Stream<CharacteristicWithValue> monitorCharacteristicForDevice(
     Peripheral peripheral,
-    String serviceUUID,
-    String characteristicUUID,
+    String serviceUuid,
+    String characteristicUuid,
     String transactionId,
   );
 
@@ -97,14 +97,14 @@ abstract class ManagerForService {
   Future<CharacteristicWithValue> readCharacteristicForService(
     Peripheral peripheral,
     InternalService service,
-    String characteristicUUID,
+    String characteristicUuid,
     String transactionId,
   );
 
   Future<Characteristic> writeCharacteristicForService(
     Peripheral peripheral,
     InternalService service,
-    String characteristicUUID,
+    String characteristicUuid,
     Uint8List bytes,
     bool withResponse,
     String transactionId,
@@ -113,7 +113,7 @@ abstract class ManagerForService {
   Stream<CharacteristicWithValue> monitorCharacteristicForService(
     Peripheral peripheral,
     InternalService service,
-    String characteristicUUID,
+    String characteristicUuid,
     String transactionId,
   );
 

--- a/lib/src/bridge/characteristics_mixin.dart
+++ b/lib/src/bridge/characteristics_mixin.dart
@@ -28,7 +28,7 @@ mixin CharacteristicsMixin on FlutterBLE {
   Future<CharacteristicWithValue> readCharacteristicForDevice(
     Peripheral peripheral,
     String serviceUuid,
-    String characteristicUUID,
+    String characteristicUuid,
     String transactionId,
   ) =>
       _methodChannel
@@ -37,7 +37,7 @@ mixin CharacteristicsMixin on FlutterBLE {
             <String, dynamic>{
               ArgumentName.deviceIdentifier: peripheral.identifier,
               ArgumentName.serviceUuid: serviceUuid,
-              ArgumentName.characteristicUuid: characteristicUUID,
+              ArgumentName.characteristicUuid: characteristicUuid,
               ArgumentName.transactionId: transactionId
             },
           )
@@ -52,7 +52,7 @@ mixin CharacteristicsMixin on FlutterBLE {
   Future<CharacteristicWithValue> readCharacteristicForService(
     Peripheral peripheral,
     int serviceIdentifier,
-    String characteristicUUID,
+    String characteristicUuid,
     String transactionId,
   ) =>
       _methodChannel
@@ -60,7 +60,7 @@ mixin CharacteristicsMixin on FlutterBLE {
             MethodName.readCharacteristicForService,
             <String, dynamic>{
               ArgumentName.serviceIdentifier: serviceIdentifier,
-              ArgumentName.characteristicUuid: characteristicUUID,
+              ArgumentName.characteristicUuid: characteristicUuid,
               ArgumentName.transactionId: transactionId
             },
           )
@@ -92,8 +92,8 @@ mixin CharacteristicsMixin on FlutterBLE {
 
   Future<Characteristic> writeCharacteristicForDevice(
           Peripheral peripheral,
-          String serviceUUID,
-          String characteristicUUID,
+          String serviceUuid,
+          String characteristicUuid,
           Uint8List bytes,
           bool withResponse,
           String transactionId) =>
@@ -102,8 +102,8 @@ mixin CharacteristicsMixin on FlutterBLE {
             MethodName.writeCharacteristicForDevice,
             <String, dynamic>{
               ArgumentName.deviceIdentifier: peripheral.identifier,
-              ArgumentName.serviceUuid: serviceUUID,
-              ArgumentName.characteristicUuid: characteristicUUID,
+              ArgumentName.serviceUuid: serviceUuid,
+              ArgumentName.characteristicUuid: characteristicUuid,
               ArgumentName.value: bytes,
               ArgumentName.withResponse: withResponse,
               ArgumentName.transactionId: transactionId,
@@ -119,7 +119,7 @@ mixin CharacteristicsMixin on FlutterBLE {
   Future<Characteristic> writeCharacteristicForService(
     Peripheral peripheral,
     int serviceIdentifier,
-    String characteristicUUID,
+    String characteristicUuid,
     Uint8List bytes,
     bool withResponse,
     String transactionId,
@@ -129,7 +129,7 @@ mixin CharacteristicsMixin on FlutterBLE {
             MethodName.writeCharacteristicForService,
             <String, dynamic>{
               ArgumentName.serviceIdentifier: serviceIdentifier,
-              ArgumentName.characteristicUuid: characteristicUUID,
+              ArgumentName.characteristicUuid: characteristicUuid,
               ArgumentName.value: bytes,
               ArgumentName.withResponse: withResponse,
               ArgumentName.transactionId: transactionId,
@@ -172,7 +172,7 @@ mixin CharacteristicsMixin on FlutterBLE {
   Stream<CharacteristicWithValue> monitorCharacteristicForDevice(
     Peripheral peripheral,
     String serviceUuid,
-    String characteristicUUID,
+    String characteristicUuid,
     String transactionId,
   ) {
     void Function() startMonitoring = () => _methodChannel.invokeMethod(
@@ -180,14 +180,14 @@ mixin CharacteristicsMixin on FlutterBLE {
           <String, dynamic>{
             ArgumentName.deviceIdentifier: peripheral.identifier,
             ArgumentName.serviceUuid: serviceUuid,
-            ArgumentName.characteristicUuid: characteristicUUID,
+            ArgumentName.characteristicUuid: characteristicUuid,
             ArgumentName.transactionId: transactionId,
           },
         );
 
     bool Function(CharacteristicWithValueAndTransactionId)
         characteristicsFilter = (characteristic) =>
-            equalsIgnoreAsciiCase(characteristicUUID, characteristic.uuid) &&
+            equalsIgnoreAsciiCase(characteristicUuid, characteristic.uuid) &&
             equalsIgnoreAsciiCase(serviceUuid, characteristic.service.uuid) &&
             equalsIgnoreAsciiCase(
                 transactionId ?? "", characteristic.transactionId ?? "");
@@ -203,21 +203,21 @@ mixin CharacteristicsMixin on FlutterBLE {
   Stream<CharacteristicWithValue> monitorCharacteristicForService(
     Peripheral peripheral,
     int serviceIdentifier,
-    String characteristicUUID,
+    String characteristicUuid,
     String transactionId,
   ) {
     void Function() startMonitoring = () => _methodChannel.invokeMethod(
           MethodName.monitorCharacteristicForService,
           <String, dynamic>{
             ArgumentName.serviceIdentifier: serviceIdentifier,
-            ArgumentName.characteristicUuid: characteristicUUID,
+            ArgumentName.characteristicUuid: characteristicUuid,
             ArgumentName.transactionId: transactionId,
           },
         );
 
     bool Function(CharacteristicWithValueAndTransactionId)
         characteristicFilter = (characteristic) =>
-            equalsIgnoreAsciiCase(characteristicUUID, characteristic.uuid) &&
+            equalsIgnoreAsciiCase(characteristicUuid, characteristic.uuid) &&
             serviceIdentifier == characteristic.service._id &&
             equalsIgnoreAsciiCase(
                 transactionId ?? "", characteristic.transactionId ?? "");

--- a/lib/src/bridge/characteristics_mixin.dart
+++ b/lib/src/bridge/characteristics_mixin.dart
@@ -75,7 +75,7 @@ mixin CharacteristicsMixin on FlutterBLE {
   Future<void> writeCharacteristicForIdentifier(
     Peripheral peripheral,
     int characteristicIdentifier,
-    Uint8List bytes,
+    Uint8List value,
     bool withResponse,
     String transactionId,
   ) =>
@@ -83,7 +83,7 @@ mixin CharacteristicsMixin on FlutterBLE {
         MethodName.writeCharacteristicForIdentifier,
         <String, dynamic>{
           ArgumentName.characteristicIdentifier: characteristicIdentifier,
-          ArgumentName.value: bytes,
+          ArgumentName.value: value,
           ArgumentName.withResponse: withResponse,
           ArgumentName.transactionId: transactionId,
         },
@@ -94,7 +94,7 @@ mixin CharacteristicsMixin on FlutterBLE {
           Peripheral peripheral,
           String serviceUuid,
           String characteristicUuid,
-          Uint8List bytes,
+          Uint8List value,
           bool withResponse,
           String transactionId) =>
       _methodChannel
@@ -104,7 +104,7 @@ mixin CharacteristicsMixin on FlutterBLE {
               ArgumentName.deviceIdentifier: peripheral.identifier,
               ArgumentName.serviceUuid: serviceUuid,
               ArgumentName.characteristicUuid: characteristicUuid,
-              ArgumentName.value: bytes,
+              ArgumentName.value: value,
               ArgumentName.withResponse: withResponse,
               ArgumentName.transactionId: transactionId,
             },
@@ -120,7 +120,7 @@ mixin CharacteristicsMixin on FlutterBLE {
     Peripheral peripheral,
     int serviceIdentifier,
     String characteristicUuid,
-    Uint8List bytes,
+    Uint8List value,
     bool withResponse,
     String transactionId,
   ) =>
@@ -130,7 +130,7 @@ mixin CharacteristicsMixin on FlutterBLE {
             <String, dynamic>{
               ArgumentName.serviceIdentifier: serviceIdentifier,
               ArgumentName.characteristicUuid: characteristicUuid,
-              ArgumentName.value: bytes,
+              ArgumentName.value: value,
               ArgumentName.withResponse: withResponse,
               ArgumentName.transactionId: transactionId,
             },

--- a/lib/src/bridge/devices_mixin.dart
+++ b/lib/src/bridge/devices_mixin.dart
@@ -12,10 +12,10 @@ mixin DevicesMixin on FlutterBLE {
     });
   }
 
-  Future<List<Peripheral>> connectedDevices(List<String> serviceUUIDs) async {
+  Future<List<Peripheral>> connectedDevices(List<String> serviceUuids) async {
     return _methodChannel
         .invokeMethod(MethodName.connectedDevices, <String, dynamic>{
-      ArgumentName.uuids: serviceUUIDs,
+      ArgumentName.uuids: serviceUuids,
     }).then((peripheralsJson) {
       print("connected devices json: $peripheralsJson");
       return _parsePeripheralsJson(peripheralsJson);

--- a/lib/src/internal_ble_manager.dart
+++ b/lib/src/internal_ble_manager.dart
@@ -184,8 +184,8 @@ class InternalBleManager
   }
 
   @override
-  Future<List<Peripheral>> connectedPeripherals(List<String> serviceUUIDs) {
-    return _bleLib.connectedDevices(serviceUUIDs ?? []);
+  Future<List<Peripheral>> connectedPeripherals(List<String> serviceUuids) {
+    return _bleLib.connectedDevices(serviceUuids ?? []);
   }
 
   @override
@@ -201,12 +201,12 @@ class InternalBleManager
   Future<CharacteristicWithValue> readCharacteristicForDevice(
           Peripheral peripheral,
           String serviceUuid,
-          String characteristicUUID,
+          String characteristicUuid,
           String transactionId) =>
       _bleLib.readCharacteristicForDevice(
         peripheral,
         serviceUuid,
-        characteristicUUID,
+        characteristicUuid,
         transactionId,
       );
 
@@ -214,12 +214,12 @@ class InternalBleManager
   Future<CharacteristicWithValue> readCharacteristicForService(
           Peripheral peripheral,
           InternalService service,
-          String characteristicUUID,
+          String characteristicUuid,
           String transactionId) =>
       _bleLib.readCharacteristicForService(
         peripheral,
         service._id,
-        characteristicUUID,
+        characteristicUuid,
         transactionId,
       );
 
@@ -241,15 +241,15 @@ class InternalBleManager
   @override
   Future<Characteristic> writeCharacteristicForDevice(
           Peripheral peripheral,
-          String serviceUUID,
-          String characteristicUUID,
+          String serviceUuid,
+          String characteristicUuid,
           Uint8List bytes,
           bool withResponse,
           String transactionId) =>
       _bleLib.writeCharacteristicForDevice(
         peripheral,
-        serviceUUID,
-        characteristicUUID,
+        serviceUuid,
+        characteristicUuid,
         bytes,
         withResponse,
         transactionId,
@@ -259,14 +259,14 @@ class InternalBleManager
   Future<Characteristic> writeCharacteristicForService(
           Peripheral peripheral,
           InternalService service,
-          String characteristicUUID,
+          String characteristicUuid,
           Uint8List bytes,
           bool withResponse,
           String transactionId) =>
       _bleLib.writeCharacteristicForService(
         peripheral,
         service._id,
-        characteristicUUID,
+        characteristicUuid,
         bytes,
         withResponse,
         transactionId,
@@ -275,14 +275,14 @@ class InternalBleManager
   @override
   Stream<CharacteristicWithValue> monitorCharacteristicForDevice(
     Peripheral peripheral,
-    String serviceUUID,
-    String characteristicUUID,
+    String serviceUuid,
+    String characteristicUuid,
     String transactionId,
   ) =>
       _bleLib.monitorCharacteristicForDevice(
         peripheral,
-        serviceUUID,
-        characteristicUUID,
+        serviceUuid,
+        characteristicUuid,
         transactionId,
       );
 
@@ -290,13 +290,13 @@ class InternalBleManager
   Stream<CharacteristicWithValue> monitorCharacteristicForService(
     Peripheral peripheral,
     InternalService service,
-    String characteristicUUID,
+    String characteristicUuid,
     String transactionId,
   ) =>
       _bleLib.monitorCharacteristicForService(
         peripheral,
         service._id,
-        characteristicUUID,
+        characteristicUuid,
         transactionId,
       );
 

--- a/lib/src/internal_ble_manager.dart
+++ b/lib/src/internal_ble_manager.dart
@@ -227,13 +227,13 @@ class InternalBleManager
   Future<void> writeCharacteristicForIdentifier(
           Peripheral peripheral,
           InternalCharacteristic characteristic,
-          Uint8List bytes,
+          Uint8List value,
           bool withResponse,
           String transactionId) =>
       _bleLib.writeCharacteristicForIdentifier(
         peripheral,
         characteristic._id,
-        bytes,
+        value,
         withResponse,
         transactionId,
       );
@@ -243,14 +243,14 @@ class InternalBleManager
           Peripheral peripheral,
           String serviceUuid,
           String characteristicUuid,
-          Uint8List bytes,
+          Uint8List value,
           bool withResponse,
           String transactionId) =>
       _bleLib.writeCharacteristicForDevice(
         peripheral,
         serviceUuid,
         characteristicUuid,
-        bytes,
+        value,
         withResponse,
         transactionId,
       );
@@ -260,14 +260,14 @@ class InternalBleManager
           Peripheral peripheral,
           InternalService service,
           String characteristicUuid,
-          Uint8List bytes,
+          Uint8List value,
           bool withResponse,
           String transactionId) =>
       _bleLib.writeCharacteristicForService(
         peripheral,
         service._id,
         characteristicUuid,
-        bytes,
+        value,
         withResponse,
         transactionId,
       );


### PR DESCRIPTION
In some places there was a different capitalization for the `UUID` part of names. This PR capitalizes all `UUID`s like regular words - `Uuid`, except strings and comments. Reference: [DO capitalize acronyms and abbreviations longer than two letters like words](https://dart.dev/guides/language/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words).

I also found `SCREAMING_CAPS`and `UpperCamelCase ` styles in constant names in `ble_error.dart`, so I also fixed it by applying the style preferred by Dart. Reference: [PREFER using lowerCamelCase for constant names](https://dart.dev/guides/language/effective-dart/style#prefer-using-lowercamelcase-for-constant-names).

There was a naming inconsistency for a parameter holding the value of a characteristic. In some places it was named `bytes`. I renamed it to `value` wherever I found it. 