### PR TITLE
[iOS] Fixed casting of Bool arguments received from dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.4
+
+* Fix issue with characteristic write without response operation on iOS
+
 ## 2.2.3
 
 * Fix issue with duplicated or malformed notification values

--- a/ios/Classes/FlutterBleLibPlugin.m
+++ b/ios/Classes/FlutterBleLibPlugin.m
@@ -230,7 +230,7 @@
 }
 
 - (void)observeConnectionState:(FlutterMethodCall *)call result:(FlutterResult)result {
-    BOOL emitCurrentValue = (BOOL)call.arguments[ARGUMENT_KEY_EMIT_CURRENT_VALUE];
+    BOOL emitCurrentValue = ((NSNumber *)call.arguments[ARGUMENT_KEY_EMIT_CURRENT_VALUE]).boolValue;
     if (emitCurrentValue == YES) {
         Resolve resolve = ^(id isConnected) {
             if ((BOOL)isConnected == YES) {
@@ -343,7 +343,7 @@
                                serviceUUID:call.arguments[ARGUMENT_KEY_SERVICE_UUID]
                         characteristicUUID:call.arguments[ARGUMENT_KEY_CHARACTERISTIC_UUID]
                                valueBase64:[self base64encodedStringFromBytes:call.arguments[ARGUMENT_KEY_VALUE]]
-                                  response:(BOOL)call.arguments[ARGUMENT_KEY_WITH_RESPONSE]
+                                  response:((NSNumber *)call.arguments[ARGUMENT_KEY_WITH_RESPONSE]).boolValue
                              transactionId:[ArgumentHandler stringOrNil:call.arguments[ARGUMENT_KEY_TRANSACTION_ID]]
                                    resolve:[self resolveForReadWriteCharacteristic:result
                                                                      transactionId:[ArgumentHandler stringOrNil:call.arguments[ARGUMENT_KEY_TRANSACTION_ID]]]
@@ -354,7 +354,7 @@
     [_adapter writeCharacteristicForService:[call.arguments[ARGUMENT_KEY_SERVICE_ID] doubleValue]
                          characteristicUUID:call.arguments[ARGUMENT_KEY_CHARACTERISTIC_UUID]
                                 valueBase64:[self base64encodedStringFromBytes:call.arguments[ARGUMENT_KEY_VALUE]]
-                                   response:(BOOL)call.arguments[ARGUMENT_KEY_WITH_RESPONSE]
+                                   response:((NSNumber *)call.arguments[ARGUMENT_KEY_WITH_RESPONSE]).boolValue
                               transactionId:[ArgumentHandler stringOrNil:call.arguments[ARGUMENT_KEY_TRANSACTION_ID]]
                                     resolve:[self resolveForReadWriteCharacteristic:result
                                                                       transactionId:[ArgumentHandler stringOrNil:call.arguments[ARGUMENT_KEY_TRANSACTION_ID]]]
@@ -364,7 +364,7 @@
 - (void)writeCharacteristic:(FlutterMethodCall *)call result:(FlutterResult)result {
     [_adapter writeCharacteristic:[call.arguments[ARGUMENT_KEY_CHARACTERISTIC_IDENTIFIER] doubleValue]
                       valueBase64:[self base64encodedStringFromBytes:call.arguments[ARGUMENT_KEY_VALUE]]
-                         response:(BOOL)call.arguments[ARGUMENT_KEY_WITH_RESPONSE]
+                         response:((NSNumber *)call.arguments[ARGUMENT_KEY_WITH_RESPONSE]).boolValue
                     transactionId:[ArgumentHandler stringOrNil:call.arguments[ARGUMENT_KEY_TRANSACTION_ID]]
                           resolve:[self resolveForReadWriteCharacteristic:result
                                                             transactionId:[ArgumentHandler stringOrNil:call.arguments[ARGUMENT_KEY_TRANSACTION_ID]]]


### PR DESCRIPTION
Fixes #364 
In iOS native part of the library, bool arguments received from Dart part were cast in an inappropriate way.

As a result, `withResponse` flag of write characteristic operation was always received with `true` value on iOS native part, regardless of what was requested by the Dart part, which in turn resulted in an error.