### PR TITLE
Fixed race condition in scan peripherals

### DIFF
--- a/lib/src/bridge/scanning_mixin.dart
+++ b/lib/src/bridge/scanning_mixin.dart
@@ -10,11 +10,11 @@ mixin ScanningMixin on FlutterBLE {
       (errorJson) {
         throw BleError.fromJson(jsonDecode(errorJson.details));
       },
-      test: (error) => error is PlatformException,
-    ).map((scanResultJson) => ScanResult.fromJson(
-              jsonDecode(scanResultJson),
-              _manager,
-            ));
+      test: (error) => error is PlatformException
+    ).map(
+      (scanResultJson) =>
+          ScanResult.fromJson(jsonDecode(scanResultJson), _manager),
+    );
   }
 
   Stream<ScanResult> startDeviceScan(
@@ -28,18 +28,19 @@ mixin ScanningMixin on FlutterBLE {
     }
 
     StreamController<ScanResult> sc = StreamController.broadcast(
-        onListen: () => _methodChannel.invokeMethod(
-              MethodName.startDeviceScan,
-              <String, dynamic>{
-                ArgumentName.scanMode: scanMode,
-                ArgumentName.callbackType: callbackType,
-                ArgumentName.uuids: uuids,
-                ArgumentName.allowDuplicates: allowDuplicates,
-              },
-            ),
-        onCancel: () => stopDeviceScan());
+      onListen: () => _methodChannel.invokeMethod(
+        MethodName.startDeviceScan,
+        <String, dynamic>{
+          ArgumentName.scanMode: scanMode,
+          ArgumentName.callbackType: callbackType,
+          ArgumentName.uuids: uuids,
+          ArgumentName.allowDuplicates: allowDuplicates,
+        },
+      ),
+      onCancel: () => stopDeviceScan(),
+    );
 
-    sc.addStream(_scanEvents, cancelOnError: true).then((_) => sc?.close());
+    sc.addStream(_scanEvents, cancelOnError: true).then((_) => sc?.close(),);
 
     return sc.stream;
   }

--- a/lib/src/bridge/scanning_mixin.dart
+++ b/lib/src/bridge/scanning_mixin.dart
@@ -4,31 +4,31 @@ mixin ScanningMixin on FlutterBLE {
   Stream<ScanResult> _scanEvents;
 
   void _prepareScanEventsStream() {
-    _scanEvents =
-        const EventChannel(ChannelName.scanningEvents).receiveBroadcastStream()
-            .handleError(
-              (errorJson) {
-            throw BleError.fromJson(jsonDecode(errorJson.details));
-          },
-          test: (error) => error is PlatformException,
-        ).map((scanResultJson) =>
-            ScanResult.fromJson(
+    _scanEvents = const EventChannel(ChannelName.scanningEvents)
+        .receiveBroadcastStream()
+        .handleError(
+      (errorJson) {
+        throw BleError.fromJson(jsonDecode(errorJson.details));
+      },
+      test: (error) => error is PlatformException,
+    ).map((scanResultJson) => ScanResult.fromJson(
               jsonDecode(scanResultJson),
               _manager,
             ));
   }
 
-  Stream<ScanResult> startDeviceScan(int scanMode,
-      int callbackType,
-      List<String> uuids,
-      bool allowDuplicates,) {
+  Stream<ScanResult> startDeviceScan(
+    int scanMode,
+    int callbackType,
+    List<String> uuids,
+    bool allowDuplicates,
+  ) {
     if (_scanEvents == null) {
       _prepareScanEventsStream();
     }
 
     StreamController<ScanResult> sc = StreamController.broadcast(
-        onListen: () =>
-            _methodChannel.invokeMethod(
+        onListen: () => _methodChannel.invokeMethod(
               MethodName.startDeviceScan,
               <String, dynamic>{
                 ArgumentName.scanMode: scanMode,
@@ -37,11 +37,9 @@ mixin ScanningMixin on FlutterBLE {
                 ArgumentName.allowDuplicates: allowDuplicates,
               },
             ),
-        onCancel: () =>
-            stopDeviceScan();
+        onCancel: () => stopDeviceScan());
 
-    sc.addStream(_scanEvents, cancelOnError: true)
-        .then((_) => sc?.close());
+    sc.addStream(_scanEvents, cancelOnError: true).then((_) => sc?.close());
 
     return sc.stream;
   }

--- a/lib/src/bridge/scanning_mixin.dart
+++ b/lib/src/bridge/scanning_mixin.dart
@@ -7,14 +7,13 @@ mixin ScanningMixin on FlutterBLE {
     _scanEvents = const EventChannel(ChannelName.scanningEvents)
         .receiveBroadcastStream()
         .handleError(
-      (errorJson) {
-        throw BleError.fromJson(jsonDecode(errorJson.details));
-      },
-      test: (error) => error is PlatformException
-    ).map(
-      (scanResultJson) =>
-          ScanResult.fromJson(jsonDecode(scanResultJson), _manager),
-    );
+          (errorJson) => throw BleError.fromJson(jsonDecode(errorJson.details)),
+          test: (error) => error is PlatformException,
+        )
+        .map(
+          (scanResultJson) =>
+              ScanResult.fromJson(jsonDecode(scanResultJson), _manager),
+        );
   }
 
   Stream<ScanResult> startDeviceScan(
@@ -40,7 +39,7 @@ mixin ScanningMixin on FlutterBLE {
       onCancel: () => stopDeviceScan(),
     );
 
-    sc.addStream(_scanEvents, cancelOnError: true).then((_) => sc?.close(),);
+    sc.addStream(_scanEvents, cancelOnError: true).then((_) => sc?.close());
 
     return sc.stream;
   }

--- a/lib/src/bridge/scanning_mixin.dart
+++ b/lib/src/bridge/scanning_mixin.dart
@@ -26,7 +26,7 @@ mixin ScanningMixin on FlutterBLE {
       _prepareScanEventsStream();
     }
 
-    StreamController<ScanResult> sc = StreamController.broadcast(
+    StreamController<ScanResult> streamController = StreamController.broadcast(
       onListen: () => _methodChannel.invokeMethod(
         MethodName.startDeviceScan,
         <String, dynamic>{
@@ -39,9 +39,11 @@ mixin ScanningMixin on FlutterBLE {
       onCancel: () => stopDeviceScan(),
     );
 
-    sc.addStream(_scanEvents, cancelOnError: true).then((_) => sc?.close());
+    streamController
+        .addStream(_scanEvents, cancelOnError: true)
+        .then((_) => streamController?.close());
 
-    return sc.stream;
+    return streamController.stream;
   }
 
   Future<void> stopDeviceScan() async {

--- a/lib/src/bridge/scanning_mixin.dart
+++ b/lib/src/bridge/scanning_mixin.dart
@@ -38,9 +38,9 @@ mixin ScanningMixin on FlutterBLE {
               },
             ),
         onCancel: () =>
-            _methodChannel.invokeMethod(MethodName.stopDeviceScan));
+            stopDeviceScan();
 
-    sc.addStream(_scanEvents)
+    sc.addStream(_scanEvents, cancelOnError: true)
         .then((_) => sc?.close());
 
     return sc.stream;


### PR DESCRIPTION
Under certain circumstances a problem can be reported by the native side very quickly. Since monitoring for callbacks started after the call those responses could be delivered before anyone would start to listen.

Fixes #480 