### PR TITLE
Fix connection timeout on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+* Fix connection timeout on iOS
+
 ## 2.3.0
 
 * add `BleManager.createUnsafePeripheral()` to allow for connecting to known peripheral without launching scan first

--- a/android/src/main/java/com/polidea/flutter_ble_lib/constant/ArgumentKey.java
+++ b/android/src/main/java/com/polidea/flutter_ble_lib/constant/ArgumentKey.java
@@ -12,7 +12,7 @@ public interface ArgumentKey {
     String IS_AUTO_CONNECT = "isAutoConnect";
     String REQUEST_MTU = "requestMtu";
     String REFRESH_GATT = "refreshGatt";
-    String TIMEOUT_MILLIS = "timeoutMillis";
+    String TIMEOUT_MILLIS = "timeout";
     String EMIT_CURRENT_VALUE = "emitCurrentValue";
 
     String LOG_LEVEL = "logLevel";

--- a/ios/Classes/Constants/ArgumentKey.m
+++ b/ios/Classes/Constants/ArgumentKey.m
@@ -10,7 +10,7 @@ NSString * const ARGUMENT_KEY_DEVICE_IDENTIFIER = @"deviceIdentifier";
 NSString * const ARGUMENT_KEY_IS_AUTO_CONNECT = @"isAutoConnect";
 NSString * const ARGUMENT_KEY_REQUEST_MTU = @"requestMtu";
 NSString * const ARGUMENT_KEY_REFRESH_GATT = @"refreshGatt";
-NSString * const ARGUMENT_KEY_TIMEOUT_MILLIS = @"timeoutMillis";
+NSString * const ARGUMENT_KEY_TIMEOUT_MILLIS = @"timeout";
 NSString * const ARGUMENT_KEY_EMIT_CURRENT_VALUE = @"emitCurrentValue";
 
 NSString * const ARGUMENT_KEY_LOG_LEVEL = @"logLevel";

--- a/lib/src/_constants.dart
+++ b/lib/src/_constants.dart
@@ -97,7 +97,7 @@ abstract class ArgumentName {
   static const String isAutoConnect = "isAutoConnect";
   static const String requestMtu = "requestMtu";
   static const String refreshGatt = "refreshGatt";
-  static const String timeoutMillis = "timeoutMillis";
+  static const String timeoutMillis = "timeout";
   static const String emitCurrentValue = "emitCurrentValue";
 
   static const String serviceUuid = "serviceUuid";


### PR DESCRIPTION
Fixes #478

iOS wasn't remapping `timeoutMillis` to `timeout` (left for legacy reasons due to react-native-ble-plx compatibility). Since I'm no good with obj-c it was easier to just rename the parameter.