### PR TITLE
Fix emitting current connection state on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.1
 
 * Fix connection timeout on iOS
+* Fix emitting current connection state on iOS
 
 ## 2.3.0
 

--- a/ios/Classes/FlutterBleLibPlugin.m
+++ b/ios/Classes/FlutterBleLibPlugin.m
@@ -235,7 +235,7 @@
     BOOL emitCurrentValue = ((NSNumber *)call.arguments[ARGUMENT_KEY_EMIT_CURRENT_VALUE]).boolValue;
     if (emitCurrentValue == YES) {
         Resolve resolve = ^(id isConnected) {
-            if ((BOOL)isConnected == YES) {
+            if ([isConnected boolValue] == YES) {
                 [self.connectionStateStreamHandler onConnectedEvent:call.arguments[ARGUMENT_KEY_DEVICE_IDENTIFIER]];
             } else {
                 [self.connectionStateStreamHandler emitDisconnectedEvent:call.arguments[ARGUMENT_KEY_DEVICE_IDENTIFIER]];


### PR DESCRIPTION
For reasons unknown casting `BOOL: NO` to `BOOL` makes it a `YES`.

Fixes #540