### PR TITLE
null_safety: Updated dependency to build_runner

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 
 dev_dependencies:
   mockito: ^5.0.3
-  build_runner: ^1.12.2
+  build_runner: ^2.0.5
   pedantic: ^1.11.0
 
   flutter_test:


### PR DESCRIPTION
This commit should allow the library to be used with null_safety.
A dependency to build_runner needed to be updated to the null_safe version.